### PR TITLE
chore: update base paths for renamed repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 전국 주짓수 대회 일정을 한눈에 모아보는 비공식 캘린더입니다. 
 KBJJF, 스트릿 주짓수, 예거스 등 주요 주최 기관의 대회를 쉽게 찾아보세요.
 
-👉 [바로가기](https://teamhyeok.github.io/team-jiujitsu/?tag=kbjjf)
+👉 [바로가기](https://teamhyeok.github.io/?tag=kbjjf)
 
 ## 주요 기능
 - 주최 기관별 탭 필터: KBJJF, 스트릿 주짓수, 예거스

--- a/lib/ics.ts
+++ b/lib/ics.ts
@@ -20,10 +20,10 @@ export function eventToICS(meta: EventMeta): string {
   const lines = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
-    'PRODID:-//team-jiujitsu//EN',
+    'PRODID:-//teamhyeok.github.io//EN',
     'CALSCALE:GREGORIAN',
     'BEGIN:VEVENT',
-    `UID:${meta.slug}@team-jiujitsu`,
+    `UID:${meta.slug}@teamhyeok.github.io`,
     `DTSTAMP:${formatDateTime(new Date())}`,
     `DTSTART;VALUE=DATE:${formatDate(start)}`,
     `DTEND;VALUE=DATE:${formatDate(end)}`,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,10 @@
-/** @type {import('next').NextConfig} */
-const repoName = 'team-jiujitsu';          // ★ GitHub 레포명과 100% 동일해야 함
-const basePath = `/${repoName}`;
+import type { NextConfig } from 'next';
 
-module.exports = {
-  output: 'export',                         // 정적 내보내기
-  images: { unoptimized: true },
+const nextConfig: NextConfig = {
+  output: 'export',
   trailingSlash: true,
-  basePath,                                 // 프로젝트 페이지 배포용
-  env: { NEXT_PUBLIC_BASE_PATH: basePath },
+  images: { unoptimized: true },
 };
+
+export default nextConfig;
+

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
-Sitemap: https://teamhyeok.github.io/team-jiujitsu/sitemap.xml
+Sitemap: https://teamhyeok.github.io/sitemap.xml
 

--- a/public/sitemap-index.xml
+++ b/public/sitemap-index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>https://teamhyeok.github.io/team-jiujitsu/sitemap.xml</loc>
+    <loc>https://teamhyeok.github.io/sitemap.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://teamhyeok.github.io/team-jiujitsu/</loc>
-    <lastmod>2025-09-10</lastmod>
+    <loc>https://teamhyeok.github.io/</loc>
+    <lastmod>2025-09-13</lastmod>
   </url>
   <url>
-    <loc>https://teamhyeok.github.io/team-jiujitsu/events/</loc>
-    <lastmod>2025-09-10</lastmod>
+    <loc>https://teamhyeok.github.io/events/</loc>
+    <lastmod>2025-09-13</lastmod>
   </url>
   <url>
-    <loc>https://teamhyeok.github.io/team-jiujitsu/rules/</loc>
-    <lastmod>2025-09-10</lastmod>
+    <loc>https://teamhyeok.github.io/rules/</loc>
+    <lastmod>2025-09-13</lastmod>
   </url>
 </urlset>

--- a/scripts/generate-sitemap.cjs
+++ b/scripts/generate-sitemap.cjs
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const baseUrl = 'https://teamhyeok.github.io/team-jiujitsu';
+const baseUrl = 'https://teamhyeok.github.io';
 const pages = ['/', '/events/', '/rules/'];
 
 const today = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
## Summary
- remove project basePath settings and unused asset prefix in Next config
- update references to old `/team-jiujitsu` paths across sitemaps, robots, and ICS
- refresh generated sitemaps for new repository URL

## Testing
- `npm run lint`
- `npm run sitemap`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c546c1a640832ab0e3634f038bbace